### PR TITLE
provide API error details to the client

### DIFF
--- a/src/main/java/de/raysha/lib/telegram/bot/api/UnirestRequestExecutor.java
+++ b/src/main/java/de/raysha/lib/telegram/bot/api/UnirestRequestExecutor.java
@@ -3,6 +3,7 @@ package de.raysha.lib.telegram.bot.api;
 import com.mashape.unirest.http.Unirest;
 import com.mashape.unirest.http.exceptions.UnirestException;
 import com.mashape.unirest.request.BaseRequest;
+import de.raysha.lib.telegram.bot.api.exception.BotApiException;
 import de.raysha.lib.telegram.bot.api.exception.BotException;
 import org.json.JSONObject;
 
@@ -52,7 +53,10 @@ public class UnirestRequestExecutor implements RequestExecutor {
         }
 
         if(jsonResult.get("ok").equals(false)){
-            throw new BotException(jsonResult.getString("description"));
+            throw new BotApiException(
+                    jsonResult.optInt("error_code", -1),
+                    jsonResult.optString("error_type"),
+                    jsonResult.optString("description"));
         }
 
         return jsonResult.get("result").toString();

--- a/src/main/java/de/raysha/lib/telegram/bot/api/exception/BotApiException.java
+++ b/src/main/java/de/raysha/lib/telegram/bot/api/exception/BotApiException.java
@@ -1,0 +1,70 @@
+package de.raysha.lib.telegram.bot.api.exception;
+
+/**
+ * Error returned by Telegram Bot API.
+ *
+ * See https://core.telegram.org/api/errors
+ */
+public class BotApiException extends BotException {
+
+    /**
+     * Similar to HTTP status. Contains information on the type of error that occurred: for example,
+     * a data input error, privacy error, or server error.
+     */
+    private int errorCode;
+
+    /**
+     * A string literal in the form of /[A-Z_0-9]+/, which summarizes the problem. For example, AUTH_KEY_UNREGISTERED.
+     *
+     * Optional, could be null
+     */
+    private String errorType;
+
+    /**
+     * May contain more detailed information on the error and how to resolve it, for example: authorization required,
+     * use auth.* methods. Please note that the description text is subject to change, one should avoid tying
+     * application logic to these messages.
+     *
+     * Optional, could be null
+     */
+    private String description;
+
+    public BotApiException(int errorCode, String errorType, String description, Throwable cause) {
+        super(cause);
+        this.errorCode = errorCode;
+        this.errorType = errorType;
+        this.description = description;
+    }
+
+    public BotApiException(int errorCode, String errorType, String description) {
+        super();
+        this.errorCode = errorCode;
+        this.errorType = errorType;
+        this.description = description;
+    }
+
+    public int getErrorCode() {
+        return errorCode;
+    }
+
+    public String getErrorType() {
+        return errorType;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    @Override
+    public String getMessage() {
+        StringBuilder buf = new StringBuilder();
+        buf.append(errorCode);
+        if (errorType != null) {
+            buf.append(' ').append(errorType);
+        }
+        if (description != null) {
+            buf.append(" '").append(description).append('\'');
+        }
+        return buf.toString();
+    }
+}


### PR DESCRIPTION
Allows to handle API errors properly. See error types: https://core.telegram.org/api/errors
